### PR TITLE
Add support for saving arrays of strings to hdf5

### DIFF
--- a/traitschema/schema.py
+++ b/traitschema/schema.py
@@ -149,7 +149,7 @@ class Schema(HasTraits):
                 # data type is unicode, each element is encoded as utf-8
                 # before being saved to hdf5
                 data = getattr(self, name)
-                if trait.array and str(data.dtype).find("<U") != -1:
+                if trait.array is True and str(data.dtype).find("<U") != -1:
                     data = [s.encode('utf8') for s in data]
 
                 chunks = True if trait.array else False

--- a/traitschema/schema.py
+++ b/traitschema/schema.py
@@ -145,13 +145,12 @@ class Schema(HasTraits):
                 trait = self.trait(name)
                 # tt = trait.trait_type
 
-                # Workaround for saving arrays containing unicode
-                if trait.array:
-                    data = getattr(self, name)
-                    if str(data.dtype).find("<U") != -1:
-                        data = [s.encode('utf8') for s in data]
-                else:
-                    data = getattr(self, name)
+                # Workaround for saving arrays containing unicode. When the
+                # data type is unicode, each element is encoded as utf-8
+                # before being saved to hdf5
+                data = getattr(self, name)
+                if trait.array and str(data.dtype).find("<U") != -1:
+                    data = [s.encode('utf8') for s in data]
 
                 chunks = True if trait.array else False
 

--- a/traitschema/schema.py
+++ b/traitschema/schema.py
@@ -145,6 +145,14 @@ class Schema(HasTraits):
                 trait = self.trait(name)
                 # tt = trait.trait_type
 
+                # Workaround for saving arrays containing unicode
+                if trait.array:
+                    data = getattr(self, name)
+                    if str(data.dtype).find("<U") != -1:
+                        data = [s.encode('utf8') for s in data]
+                else:
+                    data = getattr(self, name)
+
                 chunks = True if trait.array else False
 
                 compression_kwargs = {}
@@ -155,7 +163,7 @@ class Schema(HasTraits):
                             compression_kwargs['compression_opts'] = compression_opts
 
                 dset = hfile.create_dataset('/{}'.format(name),
-                                            data=getattr(self, name),
+                                            data=data,
                                             chunks=chunks,
                                             **compression_kwargs)
                 if trait.desc is not None:


### PR DESCRIPTION
There is an outstanding bug with hdf5 when calling create_dataset using an array of unicode strings.  When a Schema has an array of strings as one of the visible traits, the to_hdf method fails. This PR follows the [suggest workaround](https://github.com/h5py/h5py/issues/289), which encodes the array of unicode strings to utf-8 before calling create_dataset